### PR TITLE
Fix sidebar width and sizebar resizing code

### DIFF
--- a/src/gdict-window.h
+++ b/src/gdict-window.h
@@ -99,7 +99,7 @@ struct _GdictWindow
   gint default_height;
   gint current_width;
   gint current_height;
-  gint sidebar_width;
+  gdouble sidebar_width_percentage;
 
   gchar *sidebar_page;
 


### PR DESCRIPTION
If it is not possible to load the window state (for example, it is
the first time that the application runs), set a default value (33%)
for the sidebar width.

This fixes bug #788621 which was causing the sidebar to extend to
the whole window (sidebar_width = 0, i.e. 100%), thus hiding the
main panel and rendering the application basically unusable when
the sidebar was enabled.

Correctly resize the sidebar panel upon window resizing or window
minimization/maximization.